### PR TITLE
Fix API controller

### DIFF
--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,5 +1,4 @@
 plugins:
   postcss-import: {}
   postcss-cssnext: {}
-  autoprefixer: {}
   tailwindcss: './app/javascript/css/tailwind.js'

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::ArticlesController < ApplicationController
   def index
     articles = Article.all.approved
-    render json: articles
+    render json: { articles: articles }
   end
 end

--- a/spec/requests/api/list_all_articles_spec.rb
+++ b/spec/requests/api/list_all_articles_spec.rb
@@ -7,7 +7,6 @@ describe "Get /api/articles" do
     
     it "returns a collection of 5 articles" do
         get '/api/articles', headers: headers
-        binding.pry
         expect(JSON.parse(response.body)['articles'].count).to eq 5
     end
 end

--- a/spec/requests/api/v1/list_all_articles_spec.rb
+++ b/spec/requests/api/v1/list_all_articles_spec.rb
@@ -7,7 +7,7 @@ describe "Get /api/articles" do
     
     it "returns a collection of 5 articles" do
         get '/api/articles', headers: headers
-    
-        expect(JSON.parse(response.body).count).to eq 5
+        binding.pry
+        expect(JSON.parse(response.body)['articles'].count).to eq 5
     end
 end


### PR DESCRIPTION
### Proposed changes

Updates API controller to set articles as an object in the JSON response.

Deletes autoprefixer from postcssrc.yml. 
Heroku complained about duplicate calls in two separate files. 
Logs suggested to remote it from postcssrc.yml and it worked. 